### PR TITLE
Adding go-redis Support

### DIFF
--- a/examples/redis/main.go
+++ b/examples/redis/main.go
@@ -47,7 +47,7 @@ func main() {
 	c.Close()
 
 	broker := celeryredis.NewBroker(
-		celeryredis.WithPool(&pool),
+		celeryredis.WithBrokerPool(&pool),
 	)
 	app := celery.NewApp(
 		celery.WithBroker(broker),

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/go-kit/log v0.2.1
 	github.com/gomodule/redigo v1.8.9
+	github.com/go-redis/redis/v9 v9.0.0-beta.2
 	github.com/google/go-cmp v0.5.8
 	github.com/google/uuid v1.3.0
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4

--- a/goredis/broker.go
+++ b/goredis/broker.go
@@ -16,8 +16,8 @@ const DefaultReceiveTimeout = 5
 // BrokerOption sets up a Broker.
 type BrokerOption func(*Broker)
 
-// WithBrokerPool sets Redis connection pool.
-func WithBrokerPool(pool *redis.Client) BrokerOption {
+// WithBrokerClient sets Redis connection pool.
+func WithBrokerClient(pool *redis.Client) BrokerOption {
 	return func(c *Broker) {
 		c.pool = pool
 	}

--- a/goredis/broker.go
+++ b/goredis/broker.go
@@ -1,0 +1,118 @@
+package goredis
+
+import (
+	"github.com/go-redis/redis/v9"
+	"time"
+)
+
+// DefaultReceiveTimeout defines how many seconds the broker's Receive command
+// should block waiting for results from Redis.
+// Larger the timeout, longer the client will have to wait for Celery app to exit.
+const DefaultReceiveTimeout = 5
+
+// Option sets up a Broker.
+type Option func(*Broker)
+
+// WithPool sets Redis connection pool.
+func WithPool(pool *redis.Client) Option {
+	return func(c *Broker) {
+		c.pool = pool
+	}
+}
+
+// NewBroker creates a broker backed by Redis.
+// By default it connects to localhost.
+func NewBroker(redisOptions *redis.Options, options ...Option) *Broker {
+	br := Broker{
+		receiveTimeout: DefaultReceiveTimeout,
+	}
+	for _, opt := range options {
+		opt(&br)
+	}
+
+	if br.pool == nil {
+		br.pool = redis.NewClient(redisOptions)
+	}
+	return &br
+}
+
+// Broker is a Redis broker that sends/receives messages from specified queues.
+type Broker struct {
+	pool           *redis.Client
+	queues         []string
+	receiveTimeout int
+}
+
+// Send inserts the specified message at the head of the queue using LPUSH command.
+// Note, the method is safe to call concurrently.
+func (br *Broker) Send(m []byte, q string) {
+	conn := br.pool.Conn()
+	defer conn.Close()
+
+	_ = conn.LPush(nil, q, m)
+}
+
+// Observe sets the queues from which the tasks should be received.
+// Note, the method is not concurrency safe.
+func (br *Broker) Observe(queues []string) {
+	br.queues = queues
+}
+
+// Receive fetches a Celery task message from a tail of one of the queues in Redis.
+// After a timeout it returns nil, nil.
+//
+// Celery relies on BRPOP command to process messages fairly, see https://github.com/celery/kombu/issues/166.
+// Redis BRPOP is a blocking list pop primitive.
+// It blocks the connection when there are no elements to pop from any of the given lists.
+// An element is popped from the tail of the first list that is non-empty,
+// with the given keys being checked in the order that they are given,
+// see https://redis.io/commands/brpop/.
+//
+// Note, the method is not concurrency safe.
+func (br *Broker) Receive() ([]byte, error) {
+	conn := br.pool.Conn()
+	defer conn.Close()
+
+	res := conn.BRPop(nil, time.Duration(br.receiveTimeout), br.queues...)
+	// Put the Celery queue name to the end of the slice for fair processing.
+	q := res.Val()[0]
+	b := res.Val()[1]
+	move2back(br.queues, q)
+	return []byte(b), nil
+}
+
+// move2back moves item v to the end of the slice ss.
+// For example, given slice [a, b, c, d, e, f] and item c,
+// the result is [a, b, d, e, f, c].
+// The running time is linear in the worst case.
+func move2back(ss []string, v string) {
+	n := len(ss)
+	if n <= 1 {
+		return
+	}
+	// Nothing to do when an item is already at the end of the slice.
+	if ss[n-1] == v {
+		return
+	}
+
+	var found bool
+	i := 0
+	for ; i < n; i++ {
+		if ss[i] == v {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
+
+	// Swap the found item with the last item in the slice,
+	// and then swap the neighbors starting from the found index i till the n-2:
+	// the last item is already in its place,
+	// and the one before it shouldn't be swapped with the last item.
+	ss[i], ss[n-1] = ss[n-1], ss[i]
+	for ; i < n-2; i++ {
+		ss[i], ss[i+1] = ss[i+1], ss[i]
+	}
+}

--- a/goredis/broker.go
+++ b/goredis/broker.go
@@ -27,7 +27,7 @@ func WithBrokerClient(pool *redis.Client) BrokerOption {
 // By default, it connects to localhost.
 func NewBroker(options ...BrokerOption) *Broker {
 	br := Broker{
-		receiveTimeout: DefaultReceiveTimeout,
+		receiveTimeout: DefaultReceiveTimeout * time.Second,
 		ctx:            context.Background(),
 	}
 	for _, opt := range options {

--- a/internal/brokertools/broker_test.go
+++ b/internal/brokertools/broker_test.go
@@ -1,7 +1,6 @@
-package redis
+package brokertools
 
 import (
-	"github.com/marselester/gopher-celery/internal/brokertools"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -52,7 +51,7 @@ func TestMove2back(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			brokertools.Move2back(tc.input, tc.v)
+			Move2back(tc.input, tc.v)
 			if diff := cmp.Diff(tc.want, tc.input); diff != "" {
 				t.Error(diff)
 			}
@@ -63,6 +62,6 @@ func TestMove2back(t *testing.T) {
 func BenchmarkMove2back(b *testing.B) {
 	ss := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"}
 	for n := 0; n < b.N; n++ {
-		move2back(ss, "a")
+		Move2back(ss, "a")
 	}
 }

--- a/internal/brokertools/move2back.go
+++ b/internal/brokertools/move2back.go
@@ -1,0 +1,37 @@
+package brokertools
+
+// Move2back moves item v to the end of the slice ss.
+// For example, given slice [a, b, c, d, e, f] and item c,
+// the result is [a, b, d, e, f, c].
+// The running time is linear in the worst case.
+func Move2back(ss []string, v string) {
+	n := len(ss)
+	if n <= 1 {
+		return
+	}
+	// Nothing to do when an item is already at the end of the slice.
+	if ss[n-1] == v {
+		return
+	}
+
+	var found bool
+	i := 0
+	for ; i < n; i++ {
+		if ss[i] == v {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return
+	}
+
+	// Swap the found item with the last item in the slice,
+	// and then swap the neighbors starting from the found index i till the n-2:
+	// the last item is already in its place,
+	// and the one before it shouldn't be swapped with the last item.
+	ss[i], ss[n-1] = ss[n-1], ss[i]
+	for ; i < n-2; i++ {
+		ss[i], ss[i+1] = ss[i+1], ss[i]
+	}
+}

--- a/redis/broker_test.go
+++ b/redis/broker_test.go
@@ -1,6 +1,7 @@
 package redis
 
 import (
+	"github.com/marselester/gopher-celery/internal/brokertools"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -51,7 +52,7 @@ func TestMove2back(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			move2back(tc.input, tc.v)
+			brokertools.Move2back(tc.input, tc.v)
 			if diff := cmp.Diff(tc.want, tc.input); diff != "" {
 				t.Error(diff)
 			}


### PR DESCRIPTION
First pass at adding support for using the [go-redis](https://github.com/go-redis/redis) library with redis broker. Resolves #1  

Considerations
- is there a way to make both redis libraries optional dependencies so users don't have to install both?
- in NewBroker would be nice to allow users to pass in `redis.Options` that can be passed along to `redis.NewClient` thought about adding a new param to `NewBroker` to support this but wanted to get thoughts before changing the signature of that method.