### PR TITLE
Support blocking collection

### DIFF
--- a/config.go
+++ b/config.go
@@ -89,6 +89,13 @@ func WithMiddlewares(chain ...Middleware) Option {
 	}
 }
 
+// WithBlocking sets a flag to block the caller until the task is processed.
+func WithBlocking() Option {
+	return func(c *Config) {
+		c.blocking = true
+	}
+}
+
 // Config represents Celery settings.
 type Config struct {
 	logger     log.Logger
@@ -98,4 +105,5 @@ type Config struct {
 	protocol   int
 	maxWorkers int
 	chain      Middleware
+	blocking   bool
 }

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -27,5 +27,5 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
-	google.golang.org/protobuf v1.28.0 // indirect
+	google.golang.org/protobuf v1.33.0 // indirect
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -475,8 +475,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.33.0 h1:uNO2rsAINq/JlFpSdYEKIZ0uKD/R9cpdv0T+yoGwGmI=
+google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
We had a specific case where we want to completely block the task collection until current task is done processing. So all task execution had to be sync or blocking. So I extended the config and run option to support blocking operations. Not sure if this has any benefit to you. But here is an MR and feel free to close it if this is not something you would want to merge.

All changes should be backwards compatible. 